### PR TITLE
Fixed typo in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -266,7 +266,7 @@ for changes.
 Slackware Current
 -----------------
 
-For Slackware 'current' users must change the variable VERSION in '/etc/slpkg.conf' file.
+For Slackware 'current' users must change the variable VERSION in '/etc/slpkg/slpkg.conf' file.
 
 .. code-block:: bash
 


### PR DESCRIPTION
Edited section on Slackware Current to use configuration file /etc/slpkg/slpkg.conf instead of /etc/slpkg.conf.